### PR TITLE
Added new action Get Indicator Reputation

### DIFF
--- a/mandiant-threat-intel/connector.py
+++ b/mandiant-threat-intel/connector.py
@@ -1,5 +1,5 @@
 """ Copyright start
-  Copyright (C) 2008 - 2022 Fortinet Inc.
+  Copyright (C) 2008 - 2024 Fortinet Inc.
   All rights reserved.
   FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
   Copyright end """

--- a/mandiant-threat-intel/connector.py
+++ b/mandiant-threat-intel/connector.py
@@ -1,8 +1,9 @@
-""" Copyright start
-  Copyright (C) 2008 - 2024 Fortinet Inc.
-  All rights reserved.
-  FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
-  Copyright end """
+"""
+Copyright start
+MIT License
+Copyright (c) 2024 Fortinet Inc
+Copyright end
+"""
 
 from connectors.core.connector import get_logger, ConnectorError, Connector
 from .operations import operations, _check_health

--- a/mandiant-threat-intel/info.json
+++ b/mandiant-threat-intel/info.json
@@ -1,13 +1,13 @@
 {
   "name": "mandiant-threat-intel",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "label": "Mandiant Threat Intelligence",
   "category": "Threat Intelligence",
   "description": "Mandiant Threat Intelligence provides automated access to indicators of compromise (IOCs) — IP addresses, domain names, URLs threat actors are using, via the indicators, allows access to full length finished intelligence in the reports, allows for notificaiton of threats to brand and keyword monitoring via the alerts, and finally allows searching for intelligence on the adversary with the search. This connector facilitates automated operations such as indicators, reports, alerts, and search collections.<br/><br/>This connector has a dependency on the <a href=\"/content-hub/all-content/?contentType=solutionpack&amp;tag=ThreatIntelManagement\" target=\"_blank\" rel=\"noopener\">Threat Intel Management Solution Pack</a>. Install the Solution Pack before enabling ingestion of Threat Feeds from this source.",
   "publisher": "Fortinet",
   "cs_approved": true,
   "cs_compatible": true,
-  "help_online": "https://docs.fortinet.com/document/fortisoar/1.1.0/mandiant-threat-intelligence/650/mandiant-threat-intelligence-v1-1-0",
+  "help_online": "",
   "icon_small_name": "small.png",
   "icon_large_name": "large.png",
   "ingestion_supported": true,
@@ -125,18 +125,15 @@
             "id": "",
             "name": "",
             "type": "",
-            "labels": [
-            ],
+            "labels": [],
             "created": "",
             "revoked": "",
             "modified": "",
             "is_family": "",
             "description": "",
             "spec_version": "",
-            "malware_types": [
-            ],
-            "object_marking_refs": [
-            ]
+            "malware_types": [],
+            "object_marking_refs": []
           },
           {
             "id": "",
@@ -163,8 +160,7 @@
           {
             "id": "",
             "type": "",
-            "labels": [
-            ],
+            "labels": [],
             "created": "",
             "pattern": "",
             "revoked": "",
@@ -174,27 +170,22 @@
             "valid_until": "",
             "pattern_type": "",
             "spec_version": "",
-            "indicator_types": [
-            ],
-            "object_marking_refs": [
-            ],
+            "indicator_types": [],
+            "object_marking_refs": [],
             "x_fireeye_com_metadata": {
-              "subscriptions": [
-              ]
+              "subscriptions": []
             }
           },
           {
             "id": "",
             "name": "",
             "type": "",
-            "labels": [
-            ],
+            "labels": [],
             "created": "",
             "revoked": "",
             "modified": "",
             "spec_version": "",
-            "infrastructure_types": [
-            ]
+            "infrastructure_types": []
           },
           {
             "id": "",
@@ -224,8 +215,7 @@
             "modified": "",
             "spec_version": "",
             "identity_class": "",
-            "object_marking_refs": [
-            ]
+            "object_marking_refs": []
           }
         ],
         "spec_version": ""
@@ -700,6 +690,29 @@
         ],
         "spec_version": ""
       },
+      "enabled": true
+    },
+    {
+      "title": "Get Indicator Reputation",
+      "operation": "get_reputation_of_indicators",
+      "category": "investigation",
+      "annotation": "get_reputation_of_indicators",
+      "description": "Retrieves reputation information from Mandiant Threat Intelligence based on the indicator value you have specified.",
+      "parameters": [
+        {
+          "title": "Indicator Value",
+          "type": "text",
+          "name": "indicatorValue",
+          "description": "Specify the indicator value whose reputation information you want to retrieve from Mandiant Threat Intelligence.",
+          "required": true,
+          "visible": true,
+          "editable": true,
+          "value": "1.1.1.1",
+          "tooltip": "Indicator whose reputation information you want to retrieve."
+
+        }
+      ],
+      "output_schema": {},
       "enabled": true
     }
   ]

--- a/mandiant-threat-intel/info.json
+++ b/mandiant-threat-intel/info.json
@@ -714,6 +714,62 @@
       ],
       "output_schema": {},
       "enabled": true
+    },
+    {
+      "operation": "execute_an_api_call",
+      "title": "Execute an API Request",
+      "annotation": "execute_an_api_call",
+      "description": "Sends an API request to any Mandiant Threat Intelligence API endpoint based on specified HTTP method, endpoint, and other input parameters that you have specified, enabling flexible API interactions tailored to user needs. ",
+      "category": "investigation",
+      "visible": true,
+      "enabled": true,
+      "parameters": [
+        {
+          "name": "method",
+          "title": "HTTP Method",
+          "type": "select",
+          "editable": true,
+          "visible": true,
+          "required": true,
+          "description": "Select an HTTP action for the request. You can select from the following options:  \n\nDELETE \n\nGET \n\nPATCH \n\nPOST \n\nPUT ",
+          "options": [
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE"
+          ]
+        },
+        {
+          "title": "Endpoint",
+          "name": "endpoint",
+          "tooltip": "Specify the target API URL path for example: collections/alerts/objects",
+          "description": "Specify the target API URL path for the request. for example: collections/alerts/objects",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": true
+        },
+        {
+          "title": "Query Parameters",
+          "name": "query_params",
+          "description": "(Optional) Specify any optional parameters to add to the URL and refine the request. ",
+          "type": "json",
+          "visible": true,
+          "editable": true,
+          "required": false
+        },
+        {
+          "name": "payload",
+          "title": "Request Payload",
+          "type": "json",
+          "editable": true,
+          "visible": true,
+          "required": false,
+          "description": "(Optional) Specify data, as JSON, to be sent as the request payload (typically for POST or PUT requests). "
+        }
+      ],
+      "output_schema": {}
     }
   ]
 }

--- a/mandiant-threat-intel/mandiant_api_auth.py
+++ b/mandiant-threat-intel/mandiant_api_auth.py
@@ -1,5 +1,5 @@
 """ Copyright start
-  Copyright (C) 2008 - 2022 Fortinet Inc.
+  Copyright (C) 2008 - 2024 Fortinet Inc.
   All rights reserved.
   FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
   Copyright end """

--- a/mandiant-threat-intel/mandiant_api_auth.py
+++ b/mandiant-threat-intel/mandiant_api_auth.py
@@ -1,8 +1,9 @@
-""" Copyright start
-  Copyright (C) 2008 - 2024 Fortinet Inc.
-  All rights reserved.
-  FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
-  Copyright end """
+"""
+Copyright start
+MIT License
+Copyright (c) 2024 Fortinet Inc
+Copyright end
+"""
 
 import requests, json
 from requests.auth import HTTPBasicAuth

--- a/mandiant-threat-intel/operations.py
+++ b/mandiant-threat-intel/operations.py
@@ -140,21 +140,16 @@ def fetch_indicators(config, params, connector_info):
 
 def get_reputation_of_indicators(config, params, connector_info):
     try:
-        #indicator_type = params.get('indicatorType')
         indicator_value = params.get('indicatorValue')
-        #endpoint = "/v4/indicator/{0}/{1}".format(indicator_type,indicator_value)
         tempList = []
         tempList.append(indicator_value)
         endpoint = "/v4/indicator"
         data = {'requests': [{'values': tempList}]}
         jsonData = json.dumps(data)
         logger.debug("JSONDATA: {0}".format(jsonData))
-        #response = make_rest_call(endpoint, 'GET', connector_info, config)
         response = make_rest_call(endpoint, 'POST', connector_info, config, data=jsonData)
         logger.debug("Response: {0}".format(response))
         if bool(response):
-            #extract_indicators(response.get('objects'), indicators)
-            #response['objects'] = indicators
             return response
         return {"objects": []}
     except Exception as err:

--- a/mandiant-threat-intel/operations.py
+++ b/mandiant-threat-intel/operations.py
@@ -1,8 +1,9 @@
-""" Copyright start
-  Copyright (C) 2008 - 2024 Fortinet Inc.
-  All rights reserved.
-  FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
-  Copyright end """
+"""
+Copyright start
+MIT License
+Copyright (c) 2024 Fortinet Inc
+Copyright end
+"""
 
 from .mandiant_api_auth import *
 from connectors.core.connector import get_logger, ConnectorError
@@ -236,6 +237,21 @@ def search_collections(config, params, connector_info):
         raise ConnectorError("{0}".format(str(err)))
 
 
+def execute_an_api_call(config, params, connector_info):
+    try:
+        endpoint = params.get("endpoint")
+        http_method = params.get("method")
+        query_params = params.get("query_params") if params.get("query_params") else None
+        payload = json.dumps(params.get("payload")) if params.get("payload") else None
+        logger.debug("Payload: {0}".format(payload))
+        response = make_rest_call(endpoint, http_method, connector_info, config, params=query_params, data=payload)
+        logger.debug("Response: {0}".format(response))
+        return response
+    except Exception as err:
+        logger.exception("{0}".format(str(err)))
+        raise ConnectorError("{0}".format(str(err)))
+
+
 def _check_health(config, connector_info):
     try:
         return check(config, connector_info)
@@ -249,6 +265,7 @@ operations = {
     'fetch_indicators': fetch_indicators,
     'get_reports': get_reports,
     'get_alerts': get_alerts,
-    'search_collections': search_collections
-    'get_reputation_of_indicators': get_reputation_of_indicators
+    'search_collections': search_collections,
+    'get_reputation_of_indicators': get_reputation_of_indicators,
+    'execute_an_api_call': execute_an_api_call
 }

--- a/mandiant-threat-intel/playbooks/playbooks.json
+++ b/mandiant-threat-intel/playbooks/playbooks.json
@@ -1096,6 +1096,82 @@
             "fetch",
             "mandiant-threat-intel"
           ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "dfe690e2-07df-4288-95c0-f7e57470a516",
+          "collection": "/api/3/workflow_collections/8a65035a-d913-4aa4-af29-c809a66000fe",
+          "triggerLimit": null,
+          "description": "Sends an API request to any Mandiant Threat Intelligence API endpoint based on specified HTTP method, endpoint, and other input parameters that you have specified, enabling flexible API interactions tailored to user needs. ",
+          "name": "Execute an API Request",
+          "tag": "#Mandiant Threat Intelligence",
+          "recordTags": [
+            "mandiant-threat-intel"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/71a56c30-ea0e-46fb-b971-1f781e2cd9be",
+          "steps": [
+            {
+              "uuid": "71a56c30-ea0e-46fb-b971-1f781e2cd9be",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "dd96c2ba-3460-4ee6-a486-d7b0c971c795",
+                "title": "Mandiant Threat Intelligence: Execute an API Request",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "9a802795-fa3d-43ad-a296-61d325c0e36a",
+              "@type": "WorkflowStep",
+              "name": "Execute an API Request",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "Mandiant Threat Intelligence",
+                "config": "''",
+                "params": [],
+                "version": "1.2.0",
+                "connector": "mandiant-threat-intel",
+                "operation": "execute_an_api_call",
+                "operationTitle": "Execute an API Request"
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "914b235f-dd80-4f87-87f6-72005cb5e827",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Execute an API Request",
+              "sourceStep": "/api/3/workflow_steps/71a56c30-ea0e-46fb-b971-1f781e2cd9be",
+              "targetStep": "/api/3/workflow_steps/9a802795-fa3d-43ad-a296-61d325c0e36a"
+            }
+          ]
         }
       ]
     }

--- a/mandiant-threat-intel/playbooks/playbooks.json
+++ b/mandiant-threat-intel/playbooks/playbooks.json
@@ -190,7 +190,7 @@
               "targetStep": "/api/3/workflow_steps/3e72643f-d03a-4a20-abc9-5a865bec70fa"
             }
           ]
-        }
+        },
         {
           "@type": "Workflow",
           "triggerLimit": null,

--- a/mandiant-threat-intel/playbooks/playbooks.json
+++ b/mandiant-threat-intel/playbooks/playbooks.json
@@ -3,7 +3,7 @@
   "data": [
     {
       "@type": "WorkflowCollection",
-      "name": "Sample - Mandiant Threat Intelligence - 1.1.0",
+      "name": "Sample - Mandiant Threat Intelligence - 1.2.0",
       "description": "Sample playbooks for \"Mandiant Threat Intelligence\" connector. If you are planning to use any of the sample playbooks in your environment, ensure that you clone those playbooks and move them to a different collection, since the sample playbook collection gets deleted during connector upgrade and delete.",
       "visible": true,
       "image": null,
@@ -46,7 +46,7 @@
                   "status": "",
                   "added_after": ""
                 },
-                "version": "1.1.0",
+                "version": "1.2.0",
                 "connector": "mandiant-threat-intel",
                 "operation": "fetch_indicators",
                 "operationTitle": "Get Indicators",
@@ -115,6 +115,84 @@
         },
         {
           "@type": "Workflow",
+          "uuid": "98f74344-aa9a-468d-b15d-af69d2adfc4f",
+          "collection": "/api/3/workflow_collections/8a65035a-d913-4aa4-af29-c809a66000fe",
+          "triggerLimit": null,
+          "description": "Retrieves reputation information from Mandiant Threat Intelligence based on the indicator value you have specified.",
+          "name": "Get Indicator Reputation",
+          "tag": "#Mandiant Threat Intelligence",
+          "recordTags": [
+            "mandiant-threat-intel"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/45256a42-de46-4669-9d0b-68eaa882072f",
+          "steps": [
+            {
+              "uuid": "45256a42-de46-4669-9d0b-68eaa882072f",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "27f418d5-a92b-4e80-9cdc-9a32add4fde8",
+                "title": "Mandiant Threat Intelligence: Get Indicator Reputation",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "3e72643f-d03a-4a20-abc9-5a865bec70fa",
+              "@type": "WorkflowStep",
+              "name": "Get Indicator Reputation",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "Mandiant Threat Intelligence",
+                "config": "",
+                "params": {
+                  "indicatorValue": "1.1.1.1"
+                },
+                "version": "1.2.0",
+                "connector": "mandiant-threat-intel",
+                "operation": "get_reputation_of_indicators",
+                "operationTitle": "Get Indicator Reputation"
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "b4d6a74e-4207-4d51-a336-87a27421bbbc",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Get Indicator Reputation",
+              "sourceStep": "/api/3/workflow_steps/45256a42-de46-4669-9d0b-68eaa882072f",
+              "targetStep": "/api/3/workflow_steps/3e72643f-d03a-4a20-abc9-5a865bec70fa"
+            }
+          ]
+        }
+        {
+          "@type": "Workflow",
           "triggerLimit": null,
           "name": "Get Alerts",
           "aliasName": null,
@@ -147,7 +225,7 @@
                   "alert_severity": "",
                   "alert_categories": ""
                 },
-                "version": "1.1.0",
+                "version": "1.2.0",
                 "connector": "mandiant-threat-intel",
                 "operation": "get_alerts",
                 "operationTitle": "Get Alerts",
@@ -277,7 +355,7 @@
                   "malware_name": "",
                   "subscription": ""
                 },
-                "version": "1.1.0",
+                "version": "1.2.0",
                 "connector": "mandiant-threat-intel",
                 "operation": "get_reports",
                 "operationTitle": "Get Reports",
@@ -374,7 +452,7 @@
                   "status": "",
                   "added_after": ""
                 },
-                "version": "1.1.0",
+                "version": "1.2.0",
                 "connector": "mandiant-threat-intel",
                 "operation": "get_indicators",
                 "operationTitle": "Get Indicators",
@@ -444,7 +522,7 @@
                   "connected_objects": "[]",
                   "include_connected_objects": false
                 },
-                "version": "1.1.0",
+                "version": "1.2.0",
                 "connector": "mandiant-threat-intel",
                 "operation": "search_collections",
                 "operationTitle": "Search Collections",
@@ -704,7 +782,7 @@
                   "status": "{{vars.status}}",
                   "added_after": "{{vars.lastPullTime}}"
                 },
-                "version": "1.1.0",
+                "version": "1.2.0",
                 "connector": "mandiant-threat-intel",
                 "operation": "fetch_indicators",
                 "operationTitle": "Fetch Indicators",
@@ -781,7 +859,7 @@
                   "status": "{{vars.status}}",
                   "added_after": "{{vars.lastPullTime}}"
                 },
-                "version": "1.1.0",
+                "version": "1.2.0",
                 "connector": "mandiant-threat-intel",
                 "operation": "fetch_indicators",
                 "operationTitle": "Get Indicators",

--- a/mandiant-threat-intel/release_notes.md
+++ b/mandiant-threat-intel/release_notes.md
@@ -2,4 +2,7 @@
 
 Following enhancements have been made to the Mandiant Threat Intelligence Connector in version 1.2.0: 
 
-- Added a new action Get Indicator Reputation.
+- Added following new actions:
+  - Get Indicator Reputation
+  - Execute an API Request
+

--- a/mandiant-threat-intel/release_notes.md
+++ b/mandiant-threat-intel/release_notes.md
@@ -1,4 +1,5 @@
-#### Following enhancements have been made to the Mandiant Threat Intelligence Connector in version 1.1.0:
+#### What's Improved
 
-- This connector version is now certified.
-- The connector now supports data ingestion using the Data Ingestion Wizard.
+Following enhancements have been made to the Mandiant Threat Intelligence Connector in version 1.2.0: 
+
+- Added a new action Get Indicator Reputation.


### PR DESCRIPTION
### Descriptions:

This PR introduces a new action for retrieving reputation information from Mandiant Threat Intelligence based on the indicator value you have specified. The following changes have been made to the Mandiant Threat Intelligence v1.2.0:

Key changes:
- Added following new actions:
   - Get Indicator Reputation.
   - Execute an API Request.

#### Checklist:
- [x] Connector installation verified.
- [x] Connector logo verified.
- [x] Actions and Playbook list verified.
- [x] Playbook tags verified.
- [x] All Playbook are in info mode verified.
- [x] All Playbook are in inactive mode verified.
